### PR TITLE
Fix triliovault_enable_tls_backend variable

### DIFF
--- a/kolla-ansible/ansible/roles/triliovault-bobcat/templates/triliovault-wlm.conf.j2
+++ b/kolla-ansible/ansible/roles/triliovault-bobcat/templates/triliovault-wlm.conf.j2
@@ -2,19 +2,19 @@
 log_config_append = /etc/triliovault-wlm/wlm_logging.conf
 
 
-{% if glance_enable_tls_backend | bool %}
+{% if triliovault_enable_tls_backend | bool %}
 my_ip = 127.0.0.1
 {% else %}
 my_ip = {{ api_interface_address }}
 {% endif %}
 
-{% if glance_enable_tls_backend | bool %}
+{% if triliovault_enable_tls_backend | bool %}
 osapi_workloads_listen = 127.0.0.1
 {% else %}
 osapi_workloads_listen = {{ api_interface_address }}
 {% endif %}
 
-{% if glance_enable_tls_backend | bool %}
+{% if triliovault_enable_tls_backend | bool %}
 triliovault_hostnames = 127.0.0.1
 {% else %}
 triliovault_hostnames = {{ api_interface_address }}


### PR DESCRIPTION
Backend TLS is currently broken for Trilio since the scripts do not deploy the proxy containers that perform the TLS termination. This corrects a condition in the template which was using a variable meant for glance (presumably as this role was once based on glance). This at least allows you to set `triliovault_enable_tls_backend: false`